### PR TITLE
Fix null recursive query strings

### DIFF
--- a/src/WorkspaceAppsClient.js
+++ b/src/WorkspaceAppsClient.js
@@ -27,7 +27,7 @@ class WorkspaceAppsClient {
       url,
       qs: {
         paging,
-        recursive: recursive ? true : null
+        recursive: !!recursive
       }
     });
   }
@@ -54,7 +54,7 @@ class WorkspaceAppsClient {
       url,
       qs: {
         paging,
-        recursive: recursive ? true : null
+        recursive: !!recursive
       }
     });
   }


### PR DESCRIPTION
The value `null` isn't accepted by `apps`, this PR fixes that.