### PR TITLE
Rename project into node-vtex-api and merge vbase client

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,13 @@
+# editorconfig.org
 root = true
 
 [*]
+end_of_line = lf
+insert_final_newline = true
 indent_style = space
 indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,35 @@
+### SublimeText ###
+*.sublime-workspace
+
+### OSX ###
+.DS_Store
+.AppleDouble
+.LSOverride
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear on external disk
+.Spotlight-V100
+.Trashes
+
+### Windows ###
+# Windows image file caches
+Thumbs.db
+ehthumbs.db
+
+# Folder config file
+Desktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# App specific
 node_modules/
+docs/_book/
+.tmp/
+.idea/
+npm-debug.log
+.build/
 lib/

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,3 @@ node_js:
 
 script:
   - npm run lint
-  - npm run prerelease
-
-cache:
-  directories:
-    - node_modules

--- a/README.md
+++ b/README.md
@@ -1,15 +1,21 @@
-# VTEX Apps Client for Node
+# VTEX I/O API Client for Node
 
-This client enables Node developers to quickly integrate with the VTEX Apps API.
+This client enables Node developers to quickly integrate with the VTEX I/O API.
 
-[![Build Status](https://travis-ci.org/vtex/apps-client-node.svg?branch=master)](https://travis-ci.org/vtex/apps-client-node)
+[![Build Status](https://travis-ci.org/vtex/node-vtex-api.svg?branch=master)](https://travis-ci.org/vtex/node-vtex-api)
 
 ## Getting started
 
-The three clients in this library are: AppsClient, SandboxesClient and WorkspaceAppsClient. Usage:
+The three clients in this library are:
+
+- AppsClient
+- RegistryClient
+- VBaseClient
+
+Usage:
 
 ```js
-import { AppsClient } from '@vtex/apps';
+import { AppsClient } from '@vtex/api';
 
 const client = new AppsClient({
   authToken: yourAuthToken,

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "babel-plugin-transform-object-rest-spread": "^6.8.0",
     "babel-preset-es2015": "^6.9.0",
     "eslint": "^2.10.2",
-    "eslint-config-vtex": "^3.0.1",
+    "eslint-config-vtex": "^4.0.0",
     "eslint-plugin-react": "^5.1.1",
     "rimraf": "^2.5.2"
   }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
   "author": "Breno Calazans (breno@vtex.com)",
   "license": "MIT",
   "dependencies": {
-    "request-promise": "^3.0.0"
+    "any-promise": "^1.3.0",
+    "form-data": "^1.0.0-rc4",
+    "requisition": "^1.7.0"
   },
   "devDependencies": {
     "babel-cli": "^6.9.0",

--- a/package.json
+++ b/package.json
@@ -1,22 +1,22 @@
 {
-  "name": "@vtex/apps",
+  "name": "@vtex/api",
   "version": "0.6.0",
-  "description": "VTEX Apps client",
+  "description": "VTEX I/O API client",
   "main": "./lib/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "babel src --out-dir lib --watch",
-    "prerelease": "rimraf lib && babel src --out-dir lib",
-    "lint": "eslint src"
+    "watch": "babel src --out-dir lib --watch",
+    "build": "babel src --out-dir lib",
+    "lint": "eslint src",
+    "prepublish": "run-s lint build"
   },
   "keywords": [
     "vtex"
   ],
   "repository": {
     "type": "git",
-    "url": "git@github.com:vtex/apps-client-node.git"
+    "url": "git@github.com:vtex/node-vtex-api.git"
   },
-  "author": "Breno Calazans (breno@vtex.com)",
   "license": "MIT",
   "dependencies": {
     "any-promise": "^1.3.0",
@@ -30,6 +30,7 @@
     "babel-preset-es2015": "^6.9.0",
     "eslint": "^2.10.2",
     "eslint-config-vtex": "^4.0.0",
+    "npm-run-all": "^2.3.0",
     "rimraf": "^2.5.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "babel-preset-es2015": "^6.9.0",
     "eslint": "^2.10.2",
     "eslint-config-vtex": "^4.0.0",
-    "eslint-plugin-react": "^5.1.1",
     "rimraf": "^2.5.2"
   }
 }

--- a/src/AppsClient.js
+++ b/src/AppsClient.js
@@ -1,4 +1,4 @@
-import request from 'request-promise'
+import request from './http'
 import getEndpointUrl from './utils/appsEndpoints.js'
 import checkRequiredParameters from './utils/required.js'
 
@@ -10,58 +10,43 @@ class AppsClient {
       ? getEndpointUrl(endpointUrl)
       : endpointUrl
     this.userAgent = userAgent
-
-    this.defaultRequestOptions = {
-      json: true,
-      headers: {
-        Authorization: `token ${this.authToken}`,
-        'User-Agent': this.userAgent,
-      },
+    this.headers = {
+      authorization: `token ${this.authToken}`,
+      'user-agent': this.userAgent,
     }
+    this.http = request.defaults({
+      headers: this.headers,
+    })
   }
 
   installApp (account, workspace, descriptor) {
     checkRequiredParameters({account, workspace, descriptor})
     const url = `${this.endpointUrl}${this.routes.Apps(account, workspace)}`
 
-    return request.post({
-      ...this.defaultRequestOptions,
-      url,
-      body: descriptor,
-    })
+    return this.http.post(url).send(descriptor).json()
   }
 
-  uninstallApp (account, workspace, vendor, name, version) {
-    checkRequiredParameters({account, workspace, vendor, name, version})
-    const url = `${this.endpointUrl}${this.routes.App(account, workspace, vendor, name, version)}`
+  uninstallApp (account, workspace, vendor, name) {
+    checkRequiredParameters({account, workspace, vendor, name})
+    const url = `${this.endpointUrl}${this.routes.App(account, workspace, vendor, name)}`
 
-    return request.delete({
-      ...this.defaultRequestOptions,
-      url,
-    })
+    return this.http.delete(url).json()
   }
 
   updateAppSettings (account, workspace, vendor, name, version, settings) {
     checkRequiredParameters({account, workspace, vendor, name, version, settings})
     const url = `${this.endpointUrl}${this.routes.App(account, workspace, vendor, name, version)}`
 
-    return request.put({
-      ...this.defaultRequestOptions,
-      url,
-      body: {
-        settings,
-      },
-    })
+    return this.http.put(url).send({
+      settings,
+    }).json()
   }
 
   updateAppTtl (account, workspace, vendor, name, version) {
     checkRequiredParameters({account, workspace, vendor, name, version})
     const url = `${this.endpointUrl}${this.routes.App(account, workspace, vendor, name, version)}`
 
-    return request.patch({
-      ...this.defaultRequestOptions,
-      url,
-    })
+    return this.http.patch(url).json()
   }
 
   listApps (account, workspace, options = {oldVersion: '', context: '', since: '', service: ''}) {
@@ -69,70 +54,50 @@ class AppsClient {
     const url = `${this.endpointUrl}${this.routes.Apps(account, workspace)}`
     const {oldVersion, context, since, service} = options
 
-    return request.get({
-      ...this.defaultRequestOptions,
-      url,
-      qs: {
-        oldVersion,
-        context,
-        since,
-        service,
-      },
-    })
+    return this.http.get(url).query({
+      oldVersion,
+      context,
+      since,
+      service,
+    }).json()
   }
 
   listAppFiles (account, workspace, vendor, name, version, {prefix = '', context = '', nextMarker = ''}) {
     checkRequiredParameters({account, workspace, vendor, name, version})
     const url = `${this.endpointUrl}${this.routes.Files(account, workspace, vendor, name, version)}`
 
-    return request.get({
-      ...this.defaultRequestOptions,
-      url,
-      qs: {
-        prefix,
-        context,
-        nextMarker,
-      },
-    })
+    return this.http.get(url).query({
+      prefix,
+      context,
+      nextMarker,
+    }).json()
   }
 
   getAppFile (account, workspace, vendor, name, version, path, context = '') {
     checkRequiredParameters({account, workspace, vendor, name, version, path})
     const url = `${this.endpointUrl}${this.routes.File(account, workspace, vendor, name, version, path)}`
 
-    return request.get({
-      ...this.defaultRequestOptions,
-      url,
-      qs: {
-        context,
-      },
-    })
+    return this.http.get(url).query({
+      context,
+    }).json()
   }
 
   getApp (account, workspace, vendor, name, version, context = '') {
     checkRequiredParameters({account, workspace, vendor, name, version})
     const url = `${this.endpointUrl}${this.routes.App(account, workspace, vendor, name, version)}`
 
-    return request.get({
-      ...this.defaultRequestOptions,
-      url,
-      qs: {
-        context,
-      },
-    })
+    return this.http.get(url).query({
+      context,
+    }).json()
   }
 
   getDependencyMap (account, workspace, service = '') {
     checkRequiredParameters({account, workspace})
     const url = `${this.endpointUrl}${this.routes.DependencyMap(account, workspace)}`
 
-    return request.get({
-      ...this.defaultRequestOptions,
-      url,
-      qs: {
-        service,
-      },
-    })
+    return this.http.get(url).query({
+      service,
+    }).json()
   }
 }
 
@@ -142,7 +107,9 @@ AppsClient.prototype.routes = {
   },
 
   App (account, workspace, vendor, name, version) {
-    return `${this.Apps(account, workspace)}/${vendor}.${name}@${version}`
+    return version
+      ? `${this.Apps(account, workspace)}/${vendor}.${name}@${version}`
+      : `${this.Apps(account, workspace)}/${vendor}.${name}`
   },
 
   Files (account, workspace, vendor, name, version) {

--- a/src/AppsClient.js
+++ b/src/AppsClient.js
@@ -1,73 +1,73 @@
-import request from 'request-promise';
-import getEndpointUrl from './utils/appsEndpoints.js';
-import checkRequiredParameters from './utils/required.js';
+import request from 'request-promise'
+import getEndpointUrl from './utils/appsEndpoints.js'
+import checkRequiredParameters from './utils/required.js'
 
 class AppsClient {
-  constructor({authToken, userAgent, endpointUrl = getEndpointUrl('STABLE')}) {
-    checkRequiredParameters({authToken, userAgent});
-    this.authToken = authToken;
+  constructor ({authToken, userAgent, endpointUrl = getEndpointUrl('STABLE')}) {
+    checkRequiredParameters({authToken, userAgent})
+    this.authToken = authToken
     this.endpointUrl = endpointUrl === 'BETA'
       ? getEndpointUrl(endpointUrl)
-      : endpointUrl;
-    this.userAgent = userAgent;
+      : endpointUrl
+    this.userAgent = userAgent
 
     this.defaultRequestOptions = {
       json: true,
       headers: {
         Authorization: `token ${this.authToken}`,
-        'User-Agent': this.userAgent
-      }
-    };
+        'User-Agent': this.userAgent,
+      },
+    }
   }
 
-  installApp(account, workspace, descriptor) {
-    checkRequiredParameters({account, workspace, descriptor});
-    const url = `${this.endpointUrl}${this.routes.Apps(account, workspace)}`;
+  installApp (account, workspace, descriptor) {
+    checkRequiredParameters({account, workspace, descriptor})
+    const url = `${this.endpointUrl}${this.routes.Apps(account, workspace)}`
 
     return request.post({
       ...this.defaultRequestOptions,
       url,
-      body: descriptor
-    });
+      body: descriptor,
+    })
   }
 
-  uninstallApp(account, workspace, vendor, name, version) {
-    checkRequiredParameters({account, workspace, vendor, name, version});
-    const url = `${this.endpointUrl}${this.routes.App(account, workspace, vendor, name, version)}`;
+  uninstallApp (account, workspace, vendor, name, version) {
+    checkRequiredParameters({account, workspace, vendor, name, version})
+    const url = `${this.endpointUrl}${this.routes.App(account, workspace, vendor, name, version)}`
 
     return request.delete({
       ...this.defaultRequestOptions,
-      url
-    });
+      url,
+    })
   }
 
-  updateAppSettings(account, workspace, vendor, name, version, settings) {
-    checkRequiredParameters({account, workspace, vendor, name, version, settings});
-    const url = `${this.endpointUrl}${this.routes.App(account, workspace, vendor, name, version)}`;
+  updateAppSettings (account, workspace, vendor, name, version, settings) {
+    checkRequiredParameters({account, workspace, vendor, name, version, settings})
+    const url = `${this.endpointUrl}${this.routes.App(account, workspace, vendor, name, version)}`
 
     return request.put({
       ...this.defaultRequestOptions,
       url,
       body: {
-        settings
-      }
-    });
+        settings,
+      },
+    })
   }
 
-  updateAppTtl(account, workspace, vendor, name, version) {
-    checkRequiredParameters({account, workspace, vendor, name, version});
-    const url = `${this.endpointUrl}${this.routes.App(account, workspace, vendor, name, version)}`;
+  updateAppTtl (account, workspace, vendor, name, version) {
+    checkRequiredParameters({account, workspace, vendor, name, version})
+    const url = `${this.endpointUrl}${this.routes.App(account, workspace, vendor, name, version)}`
 
     return request.patch({
       ...this.defaultRequestOptions,
       url,
-    });
+    })
   }
 
-  listApps(account, workspace, options = {oldVersion: '', context: '', since: '', service: ''}) {
-    checkRequiredParameters({account, workspace});
-    const url = `${this.endpointUrl}${this.routes.Apps(account, workspace)}`;
-    const {oldVersion, context, since, service} = options;
+  listApps (account, workspace, options = {oldVersion: '', context: '', since: '', service: ''}) {
+    checkRequiredParameters({account, workspace})
+    const url = `${this.endpointUrl}${this.routes.Apps(account, workspace)}`
+    const {oldVersion, context, since, service} = options
 
     return request.get({
       ...this.defaultRequestOptions,
@@ -77,13 +77,13 @@ class AppsClient {
         context,
         since,
         service,
-      }
-    });
+      },
+    })
   }
 
-  listAppFiles(account, workspace, vendor, name, version, {prefix = '', context = '', nextMarker = ''}) {
-    checkRequiredParameters({account, workspace, vendor, name, version});
-    const url = `${this.endpointUrl}${this.routes.Files(account, workspace, vendor, name, version)}`;
+  listAppFiles (account, workspace, vendor, name, version, {prefix = '', context = '', nextMarker = ''}) {
+    checkRequiredParameters({account, workspace, vendor, name, version})
+    const url = `${this.endpointUrl}${this.routes.Files(account, workspace, vendor, name, version)}`
 
     return request.get({
       ...this.defaultRequestOptions,
@@ -91,71 +91,71 @@ class AppsClient {
       qs: {
         prefix,
         context,
-        nextMarker
-      }
-    });
+        nextMarker,
+      },
+    })
   }
 
-  getAppFile(account, workspace, vendor, name, version, path, context = '') {
-    checkRequiredParameters({account, workspace, vendor, name, version, path});
-    const url = `${this.endpointUrl}${this.routes.File(account, workspace, vendor, name, version, path)}`;
+  getAppFile (account, workspace, vendor, name, version, path, context = '') {
+    checkRequiredParameters({account, workspace, vendor, name, version, path})
+    const url = `${this.endpointUrl}${this.routes.File(account, workspace, vendor, name, version, path)}`
 
     return request.get({
       ...this.defaultRequestOptions,
       url,
       qs: {
-        context
-      }
-    });
+        context,
+      },
+    })
   }
 
-  getApp(account, workspace, vendor, name, version, context = '') {
-    checkRequiredParameters({account, workspace, vendor, name, version});
-    const url = `${this.endpointUrl}${this.routes.App(account, workspace, vendor, name, version)}`;
+  getApp (account, workspace, vendor, name, version, context = '') {
+    checkRequiredParameters({account, workspace, vendor, name, version})
+    const url = `${this.endpointUrl}${this.routes.App(account, workspace, vendor, name, version)}`
 
     return request.get({
       ...this.defaultRequestOptions,
       url,
       qs: {
-        context
-      }
-    });
+        context,
+      },
+    })
   }
 
-  getDependencyMap(account, workspace, service = '') {
-    checkRequiredParameters({account, workspace});
-    const url = `${this.endpointUrl}${this.routes.DependencyMap(account, workspace)}`;
+  getDependencyMap (account, workspace, service = '') {
+    checkRequiredParameters({account, workspace})
+    const url = `${this.endpointUrl}${this.routes.DependencyMap(account, workspace)}`
 
     return request.get({
       ...this.defaultRequestOptions,
       url,
       qs: {
-        service
-      }
-    });
+        service,
+      },
+    })
   }
 }
 
 AppsClient.prototype.routes = {
-  Apps(account, workspace) {
-    return `/${account}/${workspace}/apps`;
+  Apps (account, workspace) {
+    return `/${account}/${workspace}/apps`
   },
 
-  App(account, workspace, vendor, name, version) {
-    return `${this.Apps(account, workspace)}/${vendor}.${name}@${version}`;
+  App (account, workspace, vendor, name, version) {
+    return `${this.Apps(account, workspace)}/${vendor}.${name}@${version}`
   },
 
-  Files(account, workspace, vendor, name, version) {
-    return `${this.App(account, workspace, vendor, name, version)}/files`;
+  Files (account, workspace, vendor, name, version) {
+    return `${this.App(account, workspace, vendor, name, version)}/files`
   },
 
-  File(account, workspace, vendor, name, version, path) {
-    return `${this.Files(account, workspace, vendor, name, version)}/${path}`;
+  File (account, workspace, vendor, name, version, path) {
+    return `${this.Files(account, workspace, vendor, name, version)}/${path}`
   },
 
-  DependencyMap(account, workspace) {
-    return `${this.Apps(account, workspace)}/dependencyMap`;
-  }
-};
+  DependencyMap (account, workspace) {
+    return `${this.Apps(account, workspace)}/dependencyMap`
+  },
+}
 
-export default AppsClient;
+export default AppsClient

--- a/src/RegistryClient.js
+++ b/src/RegistryClient.js
@@ -1,122 +1,122 @@
-import request from 'request-promise';
-import getEndpointUrl from './utils/appsEndpoints.js';
-import checkRequiredParameters from './utils/required.js';
+import request from 'request-promise'
+import getEndpointUrl from './utils/appsEndpoints.js'
+import checkRequiredParameters from './utils/required.js'
 
 class RegistryClient {
-  constructor({authToken, userAgent, endpointUrl = getEndpointUrl('STABLE')}) {
-    checkRequiredParameters({authToken, userAgent});
-    this.authToken = authToken;
+  constructor ({authToken, userAgent, endpointUrl = getEndpointUrl('STABLE')}) {
+    checkRequiredParameters({authToken, userAgent})
+    this.authToken = authToken
     this.endpointUrl = endpointUrl === 'BETA'
       ? getEndpointUrl(endpointUrl)
-      : endpointUrl;
-    this.userAgent = userAgent;
+      : endpointUrl
+    this.userAgent = userAgent
 
     this.defaultRequestOptions = {
       json: true,
       headers: {
         Authorization: `token ${this.authToken}`,
-        'User-Agent': this.userAgent
-      }
-    };
+        'User-Agent': this.userAgent,
+      },
+    }
   }
 
-  publishApp(account, workspace, zip, pre = false) {
-    checkRequiredParameters({account, workspace, zip});
-    const url = `${this.endpointUrl}${this.routes.Registry(account, workspace)}`;
+  publishApp (account, workspace, zip, pre = false) {
+    checkRequiredParameters({account, workspace, zip})
+    const url = `${this.endpointUrl}${this.routes.Registry(account, workspace)}`
 
     return request.post({
       ...this.defaultRequestOptions,
       url,
       qs: {
-        isPreRelease: pre
+        isPreRelease: pre,
       },
       formData: {
-        zip
-      }
-    });
+        zip,
+      },
+    })
   }
 
-  publishAppPatch(account, workspace, vendor, name, version, changes) {
-    checkRequiredParameters({account, workspace, vendor, name, version, changes});
-    const url = `${this.endpointUrl}${this.routes.RegistryAppVersion(account, workspace, vendor, name, version)}`;
+  publishAppPatch (account, workspace, vendor, name, version, changes) {
+    checkRequiredParameters({account, workspace, vendor, name, version, changes})
+    const url = `${this.endpointUrl}${this.routes.RegistryAppVersion(account, workspace, vendor, name, version)}`
 
     return request.patch({
       ...this.defaultRequestOptions,
       url,
-      body: changes
-    });
+      body: changes,
+    })
   }
 
-  listVendors(account, workspace) {
-    checkRequiredParameters({account, workspace});
-    const url = `${this.endpointUrl}${this.routes.Registry(account, workspace)}`;
+  listVendors (account, workspace) {
+    checkRequiredParameters({account, workspace})
+    const url = `${this.endpointUrl}${this.routes.Registry(account, workspace)}`
 
     return request.get({
       ...this.defaultRequestOptions,
-      url
-    });
+      url,
+    })
   }
 
-  listAppsByVendor(account, workspace, vendor) {
-    checkRequiredParameters({account, workspace, vendor});
-    const url = `${this.endpointUrl}${this.routes.RegistryVendor(account, workspace, vendor)}`;
+  listAppsByVendor (account, workspace, vendor) {
+    checkRequiredParameters({account, workspace, vendor})
+    const url = `${this.endpointUrl}${this.routes.RegistryVendor(account, workspace, vendor)}`
 
     return request.get({
       ...this.defaultRequestOptions,
-      url
-    });
+      url,
+    })
   }
 
-  listVersionsByApp(account, workspace, vendor, name, major = '') {
-    checkRequiredParameters({account, workspace, vendor, name});
-    const url = `${this.endpointUrl}${this.routes.RegistryApp(account, workspace, vendor, name)}`;
+  listVersionsByApp (account, workspace, vendor, name, major = '') {
+    checkRequiredParameters({account, workspace, vendor, name})
+    const url = `${this.endpointUrl}${this.routes.RegistryApp(account, workspace, vendor, name)}`
 
     return request.get({
       ...this.defaultRequestOptions,
       url,
       qs: {
-        major
-      }
-    });
+        major,
+      },
+    })
   }
 
-  getAppManifest(account, workspace, vendor, name, version) {
-    checkRequiredParameters({account, workspace, vendor, name, version});
-    const url = `${this.endpointUrl}${this.routes.RegistryVendor(account, workspace, vendor, name, version)}`;
+  getAppManifest (account, workspace, vendor, name, version) {
+    checkRequiredParameters({account, workspace, vendor, name, version})
+    const url = `${this.endpointUrl}${this.routes.RegistryVendor(account, workspace, vendor, name, version)}`
 
     return request.get({
       ...this.defaultRequestOptions,
-      url
-    });
+      url,
+    })
   }
 
-  unpublishApp(account, workspace, vendor, name, version) {
-    checkRequiredParameters({account, workspace, vendor, name, version});
-    const url = `${this.endpointUrl}${this.routes.RegistryVendor(account, workspace, vendor, name, version)}`;
+  unpublishApp (account, workspace, vendor, name, version) {
+    checkRequiredParameters({account, workspace, vendor, name, version})
+    const url = `${this.endpointUrl}${this.routes.RegistryVendor(account, workspace, vendor, name, version)}`
 
     return request.delete({
       ...this.defaultRequestOptions,
-      url
-    });
+      url,
+    })
   }
 }
 
 RegistryClient.prototype.routes = {
-  Registry(account, workspace) {
-    return `/${account}/${workspace}/registry`;
+  Registry (account, workspace) {
+    return `/${account}/${workspace}/registry`
   },
 
-  RegistryVendor(account, workspace, vendor) {
-    return `${this.Registry(account, workspace)}/${vendor}/apps`;
+  RegistryVendor (account, workspace, vendor) {
+    return `${this.Registry(account, workspace)}/${vendor}/apps`
   },
 
-  RegistryApp(account, workspace, vendor, name) {
-    return `${this.RegistryVendor(account, workspace, vendor)}/${name}`;
+  RegistryApp (account, workspace, vendor, name) {
+    return `${this.RegistryVendor(account, workspace, vendor)}/${name}`
   },
 
-  RegistryAppVersion(account, workspace, vendor, name, version) {
-    return `${this.RegistryApp(account, workspace, vendor, name)}/${version}`;
-  }
-};
+  RegistryAppVersion (account, workspace, vendor, name, version) {
+    return `${this.RegistryApp(account, workspace, vendor, name)}/${version}`
+  },
+}
 
-export default RegistryClient;
+export default RegistryClient

--- a/src/VBaseClient.js
+++ b/src/VBaseClient.js
@@ -1,0 +1,72 @@
+import request from './http'
+import getEndpointUrl from './utils/vbaseEndpoints.js'
+import checkRequiredParameters from './utils/required.js'
+
+class VBaseClient {
+  constructor ({authToken, userAgent, endpointUrl = getEndpointUrl('STABLE')}) {
+    checkRequiredParameters({authToken, userAgent})
+    this.authToken = authToken
+    this.endpointUrl = endpointUrl === 'BETA'
+      ? getEndpointUrl(endpointUrl)
+      : endpointUrl
+    this.userAgent = userAgent
+    this.headers = {
+      authorization: `token ${this.authToken}`,
+      'user-agent': this.userAgent,
+    }
+    this.http = request.defaults({
+      headers: this.headers,
+    })
+  }
+
+  promote (account, workspace) {
+    checkRequiredParameters({account, workspace})
+    const url = `${this.endpointUrl}${this.routes.WorkspaceMaster(account, workspace)}`
+
+    return this.http.put(url).send({workspace}).json()
+  }
+
+  list (account) {
+    checkRequiredParameters({account})
+    const url = `${this.endpointUrl}${this.routes.Account(account)}`
+
+    return this.http.get(url).json()
+  }
+
+  create (account, workspace) {
+    checkRequiredParameters({account, workspace})
+    const url = `${this.endpointUrl}${this.routes.Account(account)}`
+
+    return this.http.post(url).send({name: workspace}).json()
+  }
+
+  get (account, workspace) {
+    checkRequiredParameters({account, workspace})
+    const url = `${this.endpointUrl}${this.routes.Workspace(account, workspace)}`
+
+    return this.http.get(url).json()
+  }
+
+  delete (account, workspace) {
+    checkRequiredParameters({account, workspace})
+    const url = `${this.endpointUrl}${this.routes.Workspace(account, workspace)}`
+
+    return this.http.delete(url).json()
+  }
+}
+
+VBaseClient.prototype.routes = {
+  Account (account) {
+    return `/${account}`
+  },
+
+  Workspace (account, workspace) {
+    return `${this.Account(account)}/${workspace}`
+  },
+
+  WorkspaceMaster (account, workspace) {
+    return `${this.Workspace(account, workspace)}/master`
+  },
+}
+
+export default VBaseClient

--- a/src/http.js
+++ b/src/http.js
@@ -1,0 +1,48 @@
+import request from 'requisition'
+import Request from 'requisition/lib/request'
+
+export default request
+
+export function successful (status) {
+  return status >= 200 && status < 300
+}
+
+export function StatusCodeError (statusCode, statusMessage, response) {
+  this.name = 'StatusCodeError'
+  this.status = this.statusCode = statusCode
+  this.message = statusMessage
+  this.res = this.response = response
+
+  if (Error.captureStackTrace) {
+    Error.captureStackTrace(this)
+  }
+}
+StatusCodeError.prototype = Object.create(Error.prototype)
+StatusCodeError.prototype.constructor = StatusCodeError
+
+Request.prototype._then = Request.prototype.then
+
+Request.prototype.then = function (resolve, reject) {
+  return this._then(res => {
+    if (successful(res.statusCode)) {
+      return resolve(res)
+    }
+    const error = new StatusCodeError(res.statusCode, res.statusMessage, res)
+    if (res.is('json')) {
+      return res.json().then(body => {
+        error.error = body
+        throw error
+      })
+    }
+    throw error
+  }, reject)
+}
+
+Request.prototype.json = function () {
+  return this.then(res => {
+    if (res.is('json')) {
+      return res.json()
+    }
+    return res
+  })
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,13 @@
 import AppsClient from './AppsClient.js'
 import RegistryClient from './RegistryClient.js'
-import getEndpointUrl from './utils/appsEndpoints.js'
+import VBaseClient from './VBaseClient.js'
+import appsEndpoints from './utils/appsEndpoints.js'
+import vbaseEndpoints from './utils/vbaseEndpoints.js'
 
 module.exports = {
   AppsClient,
   RegistryClient,
-  getEndpointUrl,
+  VBaseClient,
+  appsEndpoints,
+  vbaseEndpoints,
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,9 @@
-import AppsClient from './AppsClient.js';
-import RegistryClient from './RegistryClient.js';
-import getEndpointUrl from './utils/appsEndpoints.js';
+import AppsClient from './AppsClient.js'
+import RegistryClient from './RegistryClient.js'
+import getEndpointUrl from './utils/appsEndpoints.js'
 
 module.exports = {
   AppsClient,
   RegistryClient,
-  getEndpointUrl
-};
+  getEndpointUrl,
+}

--- a/src/utils/appsEndpoints.js
+++ b/src/utils/appsEndpoints.js
@@ -1,12 +1,12 @@
 const endpoints = {
   STABLE: 'http://apps.vtex.com',
-  BETA: 'http://apps.beta.vtex.com'
-};
+  BETA: 'http://apps.beta.vtex.com',
+}
 
-export default function getUrl(env) {
+export default function getUrl (env) {
   if (!endpoints[env]) {
-    return endpoints.STABLE;
+    return endpoints.STABLE
   }
 
-  return endpoints[env];
+  return endpoints[env]
 }

--- a/src/utils/required.js
+++ b/src/utils/required.js
@@ -1,7 +1,7 @@
-export default function checkRequiredParameters(params) {
+export default function checkRequiredParameters (params) {
   for (let key in params) {
     if (params[key] === undefined) {
-      throw new Error(`${key} is a required attribute`);
+      throw new Error(`${key} is a required attribute`)
     }
   }
 }

--- a/src/utils/vbaseEndpoints.js
+++ b/src/utils/vbaseEndpoints.js
@@ -1,0 +1,12 @@
+const endpoints = {
+  STABLE: 'http://vbase.vtex.com',
+  BETA: 'http://vbase.beta.vtex.com',
+}
+
+export default function getEndpointUrl (env) {
+  if (!endpoints[env]) {
+    return endpoints.STABLE
+  }
+
+  return endpoints[env]
+}


### PR DESCRIPTION
1) The VBase and Apps client are being written in the same style, using the same utilities, and progressing at the same pace. Maintaining two projects add more pain and no benefits.

2) Our clients are currently tiny and very similar - there's no "weight" incentive to keep them apart.

3) Considering many projects use the terminology `node-$service-{client,api,sdk}`, I think we should too! Some examples:

https://github.com/DracoBlue/node-facebook-client
https://github.com/slackhq/node-slack-sdk
https://github.com/mikedeboer/node-github
https://github.com/heroku/node-heroku-client
https://github.com/andrewrk/node-s3-client

This integrates the VBase client and also renames the project to `@vtex/api`.

Upon merging, we can also change the github repo name to match (`node-vtex-api`).